### PR TITLE
feature(backend): added caching mechanism to the Docker build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 FROM python:3.12-slim
 
 WORKDIR /app
@@ -8,7 +10,8 @@ ENV TRANSFORMERS_CACHE=/app/.cache/huggingface
 
 COPY requirements.txt .
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r requirements.txt
 
 COPY app ./app
 COPY scripts ./scripts


### PR DESCRIPTION
The build caches the pip install step. By this it reduces a second build of the same branch, or state by 95%. It only becomes slower when you add a new dependency to the requirements.txt.