### PR TITLE
feature(backend): add label proposal endpoint (#72)

### DIFF
--- a/api_contract/openapi.json
+++ b/api_contract/openapi.json
@@ -174,6 +174,39 @@
         "title": "HTTPValidationError",
         "type": "object"
       },
+      "LabelProposalCreate": {
+        "properties": {
+          "category": {
+            "description": "Chosen category key, e.g. 'laugh'",
+            "title": "Category",
+            "type": "string"
+          },
+          "uuid": {
+            "description": "UUID of the sample being labeled",
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "category"
+        ],
+        "title": "LabelProposalCreate",
+        "type": "object"
+      },
+      "LabelProposalResponse": {
+        "properties": {
+          "message": {
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "title": "LabelProposalResponse",
+        "type": "object"
+      },
       "LabeledSample": {
         "properties": {
           "category": {
@@ -460,6 +493,45 @@
         "summary": "Get Labeled Samples",
         "tags": [
           "sounds"
+        ]
+      },
+      "post": {
+        "operationId": "create_labeled_sample_api_v1_sounds_labeled_samples_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LabelProposalCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LabelProposalResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Labeled Sample",
+        "tags": [
+          "labeling"
         ]
       }
     },

--- a/app/api/label_proposal_controller.py
+++ b/app/api/label_proposal_controller.py
@@ -1,0 +1,42 @@
+"""API router for label proposals.
+
+Provides the endpoint the frontend uses to submit a category for a sample.
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.db.session import get_session
+from app.schemas.label_proposal import LabelProposalCreate, LabelProposalResponse
+from app.services.label_proposal_service import (
+    LabelProposalError,
+    LabelProposalService,
+)
+
+
+router = APIRouter(
+    prefix="/sounds",
+    tags=["labeling"],
+)
+
+
+@router.post("/labeled-samples", response_model=LabelProposalResponse)
+def create_labeled_sample(
+    proposal: LabelProposalCreate,
+    session: Annotated[Session, Depends(get_session)],
+) -> LabelProposalResponse:
+    service = LabelProposalService(session)
+
+    try:
+        service.create_label_proposal(
+            uuid=proposal.uuid,
+            category_key=proposal.category,
+        )
+    except LabelProposalError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+
+    return LabelProposalResponse(
+        message=f"Received label '{proposal.category}' for sample '{proposal.uuid}'.",
+    )

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -165,24 +165,15 @@ class LabelProposal(Base):
         primary_key=True,
     )
 
-    user_id: Mapped[str] = mapped_column(
-        String(255),
-        nullable=False,
-    )
-
-    file_hash: Mapped[str] = mapped_column(
-        String(255),
+    sample_uuid: Mapped[UUID] = mapped_column(
+        PostgresUUID(as_uuid=True),
+        ForeignKey("data_overview.uuid"),
         nullable=False,
     )
 
     category_technical_key: Mapped[int] = mapped_column(
         BigInteger,
         ForeignKey("categories.technical_key"),
-        nullable=False,
-    )
-
-    display_name: Mapped[str] = mapped_column(
-        String(255),
         nullable=False,
     )
 

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 
 from app.api.sound_controller import router as sound_router
 from app.api.import_controller import router as import_router
+from app.api.label_proposal_controller import router as label_proposal_router
 
 
 def create_app() -> FastAPI:
@@ -13,6 +14,7 @@ def create_app() -> FastAPI:
 
     app.include_router(sound_router, prefix="/api/v1")
     app.include_router(import_router, prefix="/api/v1")
+    app.include_router(label_proposal_router, prefix="/api/v1")
 
     return app
 

--- a/app/repositories/label_proposal_repository.py
+++ b/app/repositories/label_proposal_repository.py
@@ -1,7 +1,9 @@
+from uuid import UUID
+
 from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
-from app.db.models import Category, LabelProposal
+from app.db.models import LabelProposal
 
 
 class LabelProposalRepository:
@@ -16,46 +18,23 @@ class LabelProposalRepository:
         )
         return list(self.session.scalars(statement).all())
 
-    def find_by_user_id(self, user_id: str) -> list[LabelProposal]:
+    def find_by_sample_uuid(self, sample_uuid: UUID) -> list[LabelProposal]:
         statement = (
             select(LabelProposal)
             .options(joinedload(LabelProposal.category))
-            .where(LabelProposal.user_id == user_id)
-            .order_by(LabelProposal.technical_key)
-        )
-        return list(self.session.scalars(statement).all())
-
-    def find_by_file_hash(self, file_hash: str) -> list[LabelProposal]:
-        statement = (
-            select(LabelProposal)
-            .options(joinedload(LabelProposal.category))
-            .where(LabelProposal.file_hash == file_hash)
+            .where(LabelProposal.sample_uuid == sample_uuid)
             .order_by(LabelProposal.technical_key)
         )
         return list(self.session.scalars(statement).all())
 
     def save(
         self,
-        user_id: str,
-        file_hash: str,
-        category_key: str,
-        display_name: str,
+        sample_uuid: UUID,
+        category_technical_key: int,
     ) -> LabelProposal:
-        category_statement = select(Category).where(
-            Category.category_key == category_key
-        )
-        category = self.session.scalars(category_statement).first()
-
-        if category is None:
-            raise ValueError(
-                f"Category with category_key '{category_key}' does not exist."
-            )
-
         label_proposal = LabelProposal(
-            user_id=user_id,
-            file_hash=file_hash,
-            category_technical_key=category.technical_key,
-            display_name=display_name,
+            sample_uuid=sample_uuid,
+            category_technical_key=category_technical_key,
         )
 
         self.session.add(label_proposal)

--- a/app/schemas/label_proposal.py
+++ b/app/schemas/label_proposal.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, Field
+
+
+class LabelProposalCreate(BaseModel):
+    uuid: str = Field(description="UUID of the sample being labeled")
+    category: str = Field(description="Chosen category key, e.g. 'laugh'")
+
+
+class LabelProposalResponse(BaseModel):
+    message: str

--- a/app/services/label_proposal_service.py
+++ b/app/services/label_proposal_service.py
@@ -1,0 +1,45 @@
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.db.models import LabelProposal
+from app.repositories.category_repository import CategoryRepository
+from app.repositories.data_overview_repository import DataOverviewRepository
+from app.repositories.label_proposal_repository import LabelProposalRepository
+
+
+class LabelProposalError(Exception):
+    pass
+
+
+class LabelProposalService:
+    def __init__(self, session: Session) -> None:
+        self.category_repository = CategoryRepository(session)
+        self.data_overview_repository = DataOverviewRepository(session)
+        self.label_proposal_repository = LabelProposalRepository(session)
+
+    def create_label_proposal(
+        self,
+        uuid: str,
+        category_key: str,
+    ) -> LabelProposal:
+        sample_uuid = self._parse_uuid(uuid)
+
+        if self.data_overview_repository.find_by_uuid(sample_uuid) is None:
+            raise LabelProposalError(f"Sample '{uuid}' does not exist.")
+
+        category = self.category_repository.find_by_category_key(category_key)
+
+        if category is None:
+            raise LabelProposalError(f"Category '{category_key}' does not exist.")
+
+        return self.label_proposal_repository.save(
+            sample_uuid=sample_uuid,
+            category_technical_key=category.technical_key,
+        )
+
+    def _parse_uuid(self, uuid: str) -> UUID:
+        try:
+            return UUID(uuid)
+        except ValueError as error:
+            raise LabelProposalError(f"Invalid UUID: '{uuid}'.") from error

--- a/liquibase/changelog/changes/003_reshape_label_proposal.sql
+++ b/liquibase/changelog/changes/003_reshape_label_proposal.sql
@@ -1,0 +1,17 @@
+--liquibase formatted sql
+
+--changeset Lujlia:013-reshape-label-proposal
+ALTER TABLE label_proposal
+    DROP COLUMN user_id,
+    DROP COLUMN file_hash,
+    DROP COLUMN display_name,
+    ADD COLUMN sample_uuid UUID NOT NULL;
+
+ALTER TABLE label_proposal
+    ADD CONSTRAINT fk_label_proposal_sample
+        FOREIGN KEY (sample_uuid)
+        REFERENCES data_overview (uuid);
+
+--changeset Lujlia:014-create-label-proposal-index-sample-uuid
+CREATE INDEX IF NOT EXISTS idx_label_proposal_sample_uuid
+    ON label_proposal (sample_uuid);

--- a/liquibase/changelog/db.changelog-master.yaml
+++ b/liquibase/changelog/db.changelog-master.yaml
@@ -8,5 +8,9 @@ databaseChangeLog:
       relativeToChangelogFile: true
 
   - include:
+      file: changes/003_reshape_label_proposal.sql
+      relativeToChangelogFile: true
+
+  - include:
       file: changes/999_load_inital_testdata.sql
       relativeToChangelogFile: true

--- a/tests/test_label_proposal_service.py
+++ b/tests/test_label_proposal_service.py
@@ -1,0 +1,81 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services import label_proposal_service
+from app.services.label_proposal_service import (
+    LabelProposalError,
+    LabelProposalService,
+)
+
+VALID_UUID = "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+
+
+def _build_service(monkeypatch, *, sample_found, category):
+    """Build a service whose repositories are replaced by fakes (no real DB)."""
+    data_overview_repo = MagicMock()
+    data_overview_repo.find_by_uuid.return_value = object() if sample_found else None
+
+    category_repo = MagicMock()
+    category_repo.find_by_category_key.return_value = category
+
+    label_proposal_repo = MagicMock()
+
+    monkeypatch.setattr(
+        label_proposal_service,
+        "DataOverviewRepository",
+        lambda session: data_overview_repo,
+    )
+    monkeypatch.setattr(
+        label_proposal_service,
+        "CategoryRepository",
+        lambda session: category_repo,
+    )
+    monkeypatch.setattr(
+        label_proposal_service,
+        "LabelProposalRepository",
+        lambda session: label_proposal_repo,
+    )
+
+    service = LabelProposalService(session=None)
+    return service, label_proposal_repo
+
+
+def test_rejects_invalid_uuid(monkeypatch):
+    service, repo = _build_service(monkeypatch, sample_found=True, category=MagicMock())
+
+    with pytest.raises(LabelProposalError):
+        service.create_label_proposal(uuid="not-a-uuid", category_key="laugh")
+
+    repo.save.assert_not_called()
+
+
+def test_rejects_unknown_sample(monkeypatch):
+    service, repo = _build_service(
+        monkeypatch, sample_found=False, category=MagicMock()
+    )
+
+    with pytest.raises(LabelProposalError):
+        service.create_label_proposal(uuid=VALID_UUID, category_key="laugh")
+
+    repo.save.assert_not_called()
+
+
+def test_rejects_unknown_category(monkeypatch):
+    service, repo = _build_service(monkeypatch, sample_found=True, category=None)
+
+    with pytest.raises(LabelProposalError):
+        service.create_label_proposal(uuid=VALID_UUID, category_key="banana")
+
+    repo.save.assert_not_called()
+
+
+def test_saves_valid_proposal(monkeypatch):
+    category = MagicMock()
+    category.technical_key = 1
+
+    service, repo = _build_service(monkeypatch, sample_found=True, category=category)
+
+    service.create_label_proposal(uuid=VALID_UUID, category_key="laugh")
+
+    repo.save.assert_called_once()


### PR DESCRIPTION
I wasn't quite sure whether to create the “label proposal” as a separate file or include it in the sound pack. I've created it as a separate file for now, since I figured this is a new feature (user interaction).


Since there's quite a bit of code, here's an overview of what I did:

- add POST /api/v1/sounds/labeled-samples to save a label proposal
- add LabelProposalCreate / LabelProposalResponse schemas
- add LabelProposalService validating uuid, sample and category
- rewrite LabelProposalRepository.save for the new table shape
- reshape label_proposal table via Liquibase migration 003
- update LabelProposal model to match the new columns
- register controller in main.py, regenerate api-contract
- add unit tests for the service
